### PR TITLE
Add a link to the user's GitHub profile

### DIFF
--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -22,10 +22,21 @@
                     <div class="dp">
                         <img :src="profile.avatar_url">
                     </div>
-                    <div class="name">
-                        <h1>{{profile.name}}</h1>
-                        <a :href="profile.blog">{{getBlog(profile.blog)}}</a>
-                    </div>
+                    <ul class="name">
+                        <li>
+                            <h1>{{profile.name}}</h1>
+                        </li>
+                        <li>
+                            <a :href="profile.html_url">
+                              {{`@${profile.login}`}}
+                            </a>
+                        </li>
+                        <li>
+                            <a :href="profile.blog">
+                              {{getBlog(profile.blog)}}
+                            </a>
+                        </li>
+                    </ul>
                 </div>
                 <div class="stats">
                     <div class="item">


### PR DESCRIPTION
Resolves #9.

I originally just added the `a` tag, but there was an issue with the animated underline. It would go the entire length of whichever link was longer. So I put them into a `ul`, which seems to make the most semantic sense.